### PR TITLE
Infos on caching policy from dropbox added

### DIFF
--- a/app/views/doc/main-faq.html
+++ b/app/views/doc/main-faq.html
@@ -32,7 +32,7 @@
 
 <p id="3">
 <b class="red big">Q: </b><b>Can I use Tatool with Amazon Mechanical Turk?</b><span class="pull-right"><a href ng-click="scrollTo('top')"><i class="fa fa-caret-up fa-lg"></i></a></span><br>
-<b class="red big">A: </b>Yes you can! Tatool Web allows you to publish your experiment via a public link which can be used as an external survey task in Amazon Mechanical Turk. Detailed instructions can be found <a ui-sref="doc({page: 'use-mturk.html'})">here</a>. 
+<b class="red big">A: </b>Yes you can! Tatool Web allows you to publish your experiment via a public link which can be used as an external survey task in Amazon Mechanical Turk. Detailed instructions can be found <a ui-sref="doc({page: 'use-mturk.html'})">here</a>.
 </p>
 
 <hr>
@@ -62,6 +62,7 @@ The <b>accuracy</b> of timing results depends on several other factors that need
 <p id="7">
 <b class="red big">Q: </b><b>How can I use my own Stimuli with tatool-web.com?</b><span class="pull-right"><a href ng-click="scrollTo('top')"><i class="fa fa-caret-up fa-lg"></i></a></span><br>
 <b class="red big">A: </b>You'll have to make your stimuli available somewhere where you can access them directly with an URL. If you don't have your own webhost, you can use your <a href="https://www.dropbox.com/en/help/16" target="_blank">dropbox public folder</a> instead, which allows you to access files directly. If you don't have a dropbox public folder (accounts after October 2012), you can still use dropbox by sharing a single file and replacing <i>www.dropbox.com</i> with <i>dl.dropboxusercontent.com</i> in your shared link.
+Unfortunately everytime a picture from dropbox is displayed, it would need to be automatically contacted (to check if the image changed in the meantime, regardless since how long). This mean that if you need precise reaction time, we would recommend using other hosting websites.
 </p>
 
 <hr>

--- a/app/views/doc/use-editor.html
+++ b/app/views/doc/use-editor.html
@@ -26,7 +26,7 @@
 
 <p><img src="../../images/doc/screen-editor-element.png" class="internal"><br>
   <i>Element and Handler Settings</i></p>
-  
+
 <p><img src="../../images/doc/screen-editor-handler.png" class="internal"><br>
   <i>Specification of Handler Settings and Properties</i></p>
 
@@ -36,7 +36,7 @@
 
 <p>Executables can be understood as experimental paradigms. They are hence the most important component of your experiment. Browse our <a ui-sref="doc({page: 'main-lib.html'})">Task Library</a> to see which tasks are available. All of these tasks allow you to use your own stimuli, and most of them are so highly generic that you can tailor them to your needs tweaking their properties. The properties are listed for each task in the Task Library.</p>
 
-<p>If you want to use your own stimuli, you'll have to make them available somewhere where you can access them directly with an URL. If you don't have your own webhost, you can use your <a href="https://www.dropbox.com/en/help/16" target="_blank">dropbox public folder</a> instead, which allows you to access files directly. If you don't have a dropbox public folder (accounts after October 2012), you can still use dropbox by sharing a single file and replacing <i>www.dropbox.com</i> with <i>dl.dropboxusercontent.com</i> in your shared link.</p>
+<p>If you want to use your own stimuli, you'll have to make them available somewhere where you can access them directly with an URL. If you don't have your own webhost, you can use your <a href="https://www.dropbox.com/en/help/16" target="_blank">dropbox public folder</a> instead, which allows you to access files directly. If you don't have a dropbox public folder (accounts after October 2012), you can still use dropbox by sharing a single file and replacing <i>www.dropbox.com</i> with <i>dl.dropboxusercontent.com</i> in your shared link. Unfortunately everytime a picture from dropbox is displayed, it would need to be automatically contacted (to check if the image changed in the meantime, regardless since how long). This mean that if you need precise reaction time, we would recommend using other hosting websites.</p>
 
 <p>You can also <a ui-sref="doc({page: 'main-dev.html'})">develop your own tasks</a>. If you're willing to share your Executables with other researchers, we'll be happy to host them for you for free! Otherwise, you can either run Tatool in offline lab mode (see <a ui-sref="doc({page: 'dev-getting-started.html'})">here</a>), host it on your own web server running Tatool, or we can host it for you in exchange for a small donation helping to cover our fixed hosting costs.</p>
 
@@ -54,7 +54,7 @@
 <p>A <b>Private</b> module restricts visibility and execution of the module to a custom-defined list of Tatool Web users. After publishing the module, you can invite Tatool Web users by clicking on the <i>Invite</i> button next to the <i>Publish</i> button. The email addresses entered in the invite screen need to be Tatool Web accounts. As soon as the invited user logs into Tatool Web he/she will see a pending invitation for a Module. After accepting the invitation you'll see the change od the invitation status on the invite screen.<br>
 Private modules come also with a URL (click on <i>Show URL</i> to get your custom link) that allows for sharing your experiment with any prospective participants without having them to sign up on Tatool Web (e.g. for <b>Amazon Mechanical Turk</b>).</p>
 
-<p>You can <i>Edit</i> your module at any time, but have to <i>Publish</i> it again to make the changes available to your users. Once you published such changes, users that have added your module first have to update it before they can execute it again. This allows for dynamic adjustments as it might be required during piloting your experiments.</p> 
+<p>You can <i>Edit</i> your module at any time, but have to <i>Publish</i> it again to make the changes available to your users. Once you published such changes, users that have added your module first have to update it before they can execute it again. This allows for dynamic adjustments as it might be required during piloting your experiments.</p>
 
 <p><b>Note:</b> To make sure that we have sufficient web space for everyone, we currently limit the number of simultaneously published modules per researcher to <b>3</b> at a time.</p>
 


### PR DESCRIPTION
Dropbox has a "no-cache" header on everything. This means that if the server will need to be touched each time the picture is used, in order to get a "Not modified" code (304). So, the image is still not downloaded again, but the it will still take quite some milliseconds until one get the code. This means for that for reaction time studies, the image might be displayed later than expected.
I don't have another solution than just warning users about it.