### PR TITLE
Added support for audio and dual (audio + image) stimuli types

### DIFF
--- a/app/scripts/module/module.directive.js
+++ b/app/scripts/module/module.directive.js
@@ -5,6 +5,7 @@
 
 import KeyCodes from './util/keycodes.js';
 import videojs from 'video.js';
+import {Howl, Howler} from 'howler';
 
 Tatool.$inject = ['$timeout', 'executableUtils', 'contextService'];
 TatoolInput.$inject = ['$log', '$templateCache', '$compile', '$timeout', 'executableUtils'];
@@ -264,14 +265,32 @@ function TatoolStimulus($log, $templateCache, $timeout, $q, cfgModule, executabl
       scope.show = false;
       scope.stimulus = scope.service;
       var videoPlayer = null;
+      var audioPlayer = null;
 
       scope.service.show = function() {
         scope.show = true;
+        scope.service.playAudio();
         return executableUtils.getTiming();
       };
 
       scope.service.hide = function() {
         scope.show = false;
+        scope.service.stopAudio();
+        return executableUtils.getTiming();
+      };
+
+      scope.service.playAudio = function() {
+        if (scope.stimulus.data.stimulusValueType.startsWith('audio')) {
+          audioPlayer = new Howl({src: scope.stimulus.stimulusAudio});
+          audioPlayer.play();
+        }
+        return executableUtils.getTiming();
+      };
+
+      scope.service.stopAudio = function() {
+        if (scope.stimulus.data.stimulusValueType.startsWith('audio') && audioPlayer !== null) {
+          audioPlayer.stop();
+        }
         return executableUtils.getTiming();
       };
 

--- a/app/scripts/module/stimulusServiceFactory.js
+++ b/app/scripts/module/stimulusServiceFactory.js
@@ -47,6 +47,36 @@ function StimulusServiceFactory($log, $sce, executableUtils) {
         if (this.data.stimulusClass !== undefined) {
           this.stimulusClass = this.data.stimulusClass;
         }
+
+        if (this.data.stimulusValueType === 'audio') 
+        {
+          var audioResource = this.stimuliPath;
+          audioResource.resourceName = this.data.stimulusValue;
+          var audSrc = executableUtils.getResourcePath(audioResource);
+
+          var sound = new Howl({src: audSrc});
+          sound.play();
+
+          this.stimulusAudio = audSrc;
+        }
+
+        if (this.data.stimulusValueType === 'dual') 
+        {
+          var imgResource = this.stimuliPath;
+          imgResource.resourceName = this.data.stimulusImage;
+          var imgSrc = executableUtils.getResourcePath(imgResource);
+          this.stimulusImage = imgSrc;
+
+          var audioResource = this.stimuliPath;
+          audioResource.resourceName = this.data.stimulusValue;
+          var audSrc = executableUtils.getResourcePath(audioResource);
+
+          var sound = new Howl({src: audSrc});
+          sound.play();
+
+          this.stimulusAudio = audSrc;
+        }
+
       };
 
       this.set = function(content) {

--- a/app/scripts/module/stimulusServiceFactory.js
+++ b/app/scripts/module/stimulusServiceFactory.js
@@ -13,11 +13,11 @@ function StimulusServiceFactory($log, $sce, executableUtils) {
     };
 
     function Stimulus() {
-      this.data = {};
+      this.data = {}; 
 
       this.init = function() {
         if (this.data.stimulusValueColor !== undefined) {
-          if (this.data.stimulusValueType === 'text') {
+          if (this.data.stimulusValueType === 'text' || this.data.stimulusValueType === 'audio-text') {
             this.stimulusStyle = {
               'color': this.data.stimulusValueColor
             };
@@ -48,33 +48,34 @@ function StimulusServiceFactory($log, $sce, executableUtils) {
           this.stimulusClass = this.data.stimulusClass;
         }
 
+        // prepare audio source
         if (this.data.stimulusValueType === 'audio') 
         {
           var audioResource = this.stimuliPath;
           audioResource.resourceName = this.data.stimulusValue;
-          var audSrc = executableUtils.getResourcePath(audioResource);
-
-          var sound = new Howl({src: audSrc});
-          sound.play();
-
-          this.stimulusAudio = audSrc;
+          var audioSrc = executableUtils.getResourcePath(audioResource);
+          this.stimulusAudio = audioSrc;
         }
 
-        if (this.data.stimulusValueType === 'dual') 
+        if (this.data.stimulusValueType === 'audio-image') 
         {
           var imgResource = this.stimuliPath;
-          imgResource.resourceName = this.data.stimulusImage;
+          imgResource.resourceName = this.data.stimulusValue;
           var imgSrc = executableUtils.getResourcePath(imgResource);
           this.stimulusImage = imgSrc;
 
           var audioResource = this.stimuliPath;
-          audioResource.resourceName = this.data.stimulusValue;
-          var audSrc = executableUtils.getResourcePath(audioResource);
+          audioResource.resourceName = this.data.stimulusAudioValue;
+          var audioSrc = executableUtils.getResourcePath(audioResource);
+          this.stimulusAudio = audioSrc;
+        }
 
-          var sound = new Howl({src: audSrc});
-          sound.play();
-
-          this.stimulusAudio = audSrc;
+        if (this.data.stimulusValueType === 'audio-text') 
+        {
+          var audioResource = this.stimuliPath;
+          audioResource.resourceName = this.data.stimulusAudioValue;
+          var audioSrc = executableUtils.getResourcePath(audioResource);
+          this.stimulusAudio = audioSrc;
         }
 
       };

--- a/app/scripts/modules/module.module.js
+++ b/app/scripts/modules/module.module.js
@@ -1,5 +1,7 @@
 'use strict';
 
+import {Howl, Howler} from 'howler';
+
 import angular from 'angular';
 import angularprogressarc from 'angular-progress-arc'
 

--- a/app/scripts/modules/module.module.js
+++ b/app/scripts/modules/module.module.js
@@ -1,7 +1,5 @@
 'use strict';
 
-import {Howl, Howler} from 'howler';
-
 import angular from 'angular';
 import angularprogressarc from 'angular-progress-arc'
 

--- a/app/views/module/tatoolStimulus.html
+++ b/app/views/module/tatoolStimulus.html
@@ -6,10 +6,13 @@
           <div ng-switch-when="image">
             <img class="imageStimulusValue" draggable="false" ng-src="{{stimulus.stimulusImage}}" ng-class="stimulus.stimulusClass" style="{{col.data.stimulusValueStyle}}">
           </div>
-          <div ng-switch-when="dual">
+          <div ng-switch-when="audio">
+            
+          </div>
+          <div ng-switch-when="audio-image">
             <img class="imageStimulusValue" draggable="false" ng-src="{{stimulus.stimulusImage}}" ng-class="stimulus.stimulusClass" style="{{col.data.stimulusValueStyle}}">
           </div>
-          <div ng-switch-when="audio" ng-style="stimulus.stimulusStyle" ng-class="stimulus.stimulusClass" style="{{col.data.stimulusValueStyle}}">
+          <div ng-switch-when="audio-text" ng-style="stimulus.stimulusStyle" ng-class="stimulus.stimulusClass" style="{{col.data.stimulusValueStyle}}">
             <div class="textStimulusValue"><span>{{stimulus.data.stimulusValue}}</span></div>
           </div>
           <div ng-switch-when="text" ng-style="stimulus.stimulusStyle" ng-class="stimulus.stimulusClass" style="{{col.data.stimulusValueStyle}}">

--- a/app/views/module/tatoolStimulus.html
+++ b/app/views/module/tatoolStimulus.html
@@ -6,6 +6,12 @@
           <div ng-switch-when="image">
             <img class="imageStimulusValue" draggable="false" ng-src="{{stimulus.stimulusImage}}" ng-class="stimulus.stimulusClass" style="{{col.data.stimulusValueStyle}}">
           </div>
+          <div ng-switch-when="dual">
+            <img class="imageStimulusValue" draggable="false" ng-src="{{stimulus.stimulusImage}}" ng-class="stimulus.stimulusClass" style="{{col.data.stimulusValueStyle}}">
+          </div>
+          <div ng-switch-when="audio" ng-style="stimulus.stimulusStyle" ng-class="stimulus.stimulusClass" style="{{col.data.stimulusValueStyle}}">
+            <div class="textStimulusValue"><span>{{stimulus.data.stimulusValue}}</span></div>
+          </div>
           <div ng-switch-when="text" ng-style="stimulus.stimulusStyle" ng-class="stimulus.stimulusClass" style="{{col.data.stimulusValueStyle}}">
             <div class="textStimulusValue"><span>{{stimulus.data.stimulusValue}}</span></div>
           </div>

--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
     "font-awesome": "4.7.0",
     "glob": "7.1.2",
     "headjs": "1.0.3",
+    "howler": "^2.0.14",
     "idb-wrapper": "1.6.1",
     "jquery": "3.0.0",
     "jquery-ui": "1.12.x",

--- a/server.js
+++ b/server.js
@@ -1,8 +1,4 @@
 // server
-// conditional load of newrelic module
-if (process.argv[2] === 'server') {
-  require('newrelic');
-}
 var express = require('express');
 var compress = require('compression');
 var os = require('os');


### PR DESCRIPTION
Resolves #112 and #39

New stimuli types dual and image. Uses howler library to implement audio. Does not prefetch audio.

Use audio in same way as other stimuli, add a file to the stimuli folder and in a csv file refer to the audio filename. Will play the audio and display the filename.

For dual, reference the audio file in the simulusValue field and the image in a new field named stimulusImage.